### PR TITLE
refactor(q): Update query handling with customizable result-set-fn

### DIFF
--- a/src/sqlite4clj/core.clj
+++ b/src/sqlite4clj/core.clj
@@ -88,16 +88,18 @@
         (reify clojure.lang.IReduceInit
           (reduce [_ f init]
             (loop [ret init]
-              (let [code (int
-                          #_{:clj-kondo/ignore [:type-mismatch]}
-                          (api/step stmt))]
-                (case code
-                  100 (let [ret (f ret (column stmt n-cols))]
-                        (if (reduced? ret)
-                          @ret
-                          (recur ret)))
-                  101 ret
-                  code)))))))))
+              (case (int
+                     #_{:clj-kondo/ignore [:type-mismatch]}
+                     (api/step stmt))
+                100 (let [ret (f ret (column stmt n-cols))]
+                      (if (reduced? ret)
+                        @ret
+                        (recur ret)))
+                101 ret
+                (throw (api/sqlite-ex-info (:pdb conn)
+                                           ret
+                                           {:sql (first query)
+                                            :params (subvec query 1)}))))))))))
 
 (def default-pragma
   {:cache_size         15625


### PR DESCRIPTION
Modified the `q*` function to enable reducing results via `IReduceInit`. Added a `result-set-fn` option in `q` to allow customization of query result transformations, defaulting to a vector (same as current behavior).


[blind shot, untested]