### PR TITLE
special case byte[] writes to prevent extra array copies

### DIFF
--- a/src/sqlite4clj/impl/api.clj
+++ b/src/sqlite4clj/impl/api.clj
@@ -171,12 +171,24 @@
    ::mem/pointer] ::mem/int
   sqlite3-bind-blob-native
   [pdb idx blob]
-  (let [blob   (enc/encode blob)
-        blob-l (count blob)]
-    (sqlite3-bind-blob-native pdb idx
-      (mem/serialize blob [::mem/array ::mem/byte blob-l])
-      blob-l
-      sqlite-transient)))
+  (if (bytes? blob)
+    ;; when writing a byte[], special case it to prevent needles array copies
+    (let [blob-l (alength ^bytes blob)
+          total  (unchecked-inc-int blob-l)]
+      (with-open [arena (mem/confined-arena)]
+        (let [segment (.allocate arena (long total))]
+          (mem/write-byte segment enc/RAW_BLOB)
+          (mem/write-bytes segment blob-l 1 ^bytes blob)
+          (sqlite3-bind-blob-native pdb idx
+            segment
+            total
+            sqlite-transient))))
+    (let [blob   (enc/encode blob)
+          blob-l (count blob)]
+      (sqlite3-bind-blob-native pdb idx
+        (mem/serialize blob [::mem/array ::mem/byte blob-l])
+        blob-l
+        sqlite-transient))))
 
 (defcfn step
   sqlite3_step

--- a/test/sqlite4clj/core_test.clj
+++ b/test/sqlite4clj/core_test.clj
@@ -109,3 +109,18 @@
       (is (= [{:id 0, :email "bob@foobar.com", :username "bob"}]
              (d/q (:reader db)
                ["select data from encoding where id = 1"]))))))
+
+(deftest encoding-raw-byte-arrays
+  (testing "Raw byte arrays round-trip unchanged and keep the prefixed blob format."
+    (with-db [db (test-db)]
+      (d/q (:writer db)
+        ["CREATE TABLE IF NOT EXISTS raw_bytes(id INT PRIMARY KEY, data BLOB)"])
+      (let [payload (byte-array [1 2 3 4 5])]
+        (d/q (:writer db)
+          ["INSERT INTO raw_bytes (id, data) VALUES (?, ?)" 1 payload])
+        (let [[stored-bytes] (d/q (:reader db)
+                              ["select data from raw_bytes where id = 1"])
+              [stored-length] (d/q (:reader db)
+                               ["select length(data) from raw_bytes where id = 1"])]
+          (is (= (seq payload) (seq stored-bytes)))
+          (is (= (inc (alength payload)) stored-length)))))))


### PR DESCRIPTION
as discussed in discord

for me the problem line is [around here](https://github.com/andersmurphy/sqlite4clj/blob/master/src/sqlite4clj/impl/api.clj#L174)

my `blob` is a `byte[]`

Before this PR the codepath is:

1. `enc/encode` allocates a new Java array of size n+1
2. `add-leading-byte` copies the original n bytes into that new Java array
3. `mem/serialize` allocates native memory of size n+1
4. `mem/serialize` copies that Java array into native memory

After this PR the work is only

1. allocate native memory of size n+1
2. write one prefix byte, ( `RAW_BLOB`)
3. copy the original n bytes directly into native memory