### PR TITLE
Add opt-in SQLite memstatus tracking via -Dsqlite4clj.memstatus=true

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,6 +362,29 @@ So something like this should work:
      :escape-slash false)})
 ```
 
+## Memory observability
+
+The bundled SQLite binaries are compiled with `SQLITE_DEFAULT_MEMSTATUS=0` for
+performance, which means `sqlite3_memory_used()` and `sqlite3_memory_highwater()`
+always return 0. To enable global memory accounting, start the JVM with:
+
+```
+-Dsqlite4clj.memstatus=true
+```
+
+When enabled, you can call:
+
+```clojure
+(sqlite4clj.core/memory-used)        ;; bytes currently allocated by SQLite
+(sqlite4clj.core/memory-highwater)   ;; high-water mark since process start
+(sqlite4clj.core/memory-highwater true) ;; read and reset the high-water mark
+```
+
+The cost of enabling memstatus is one extra atomic increment per SQLite
+allocation — measurable but tiny. Useful for diagnosing OOMs caused by
+SQLite's per-connection page caches and prepared-statement caches, which
+otherwise live outside the JVM heap and don't show up in heap dumps.
+
 ## Loading the Native Library
 
 Bundled in the classpath is pre-built libsqlite3 shared library for:

--- a/src/sqlite4clj/core.clj
+++ b/src/sqlite4clj/core.clj
@@ -273,6 +273,21 @@
       (q db ["pragma optimize=0x10002"])
       (if (> n-conn n) (recur (inc n)) n))))
 
+(defn memory-used
+  "Bytes currently allocated by SQLite globally in this process across all
+  open connections. Returns 0 unless memstatus is enabled at startup with
+  -Dsqlite4clj.memstatus=true."
+  ^long []
+  (api/memory-used))
+
+(defn memory-highwater
+  "High-water mark in bytes of SQLite's global allocator since process start
+  (or since the last reset). Pass reset?=true to reset the high-water mark.
+  Returns 0 unless memstatus is enabled at startup with
+  -Dsqlite4clj.memstatus=true."
+  (^long [] (api/memory-highwater 0))
+  (^long [reset?] (api/memory-highwater (if reset? 1 0))))
+
 (defmacro with-read-tx
   "Wrap series of queries in a read transaction."
   {:clj-kondo/lint-as 'clojure.core/with-open}

--- a/src/sqlite4clj/impl/api.clj
+++ b/src/sqlite4clj/impl/api.clj
@@ -19,6 +19,7 @@
 (def SQLITE_SUBTYPE 0x000100000)
 (def SQLITE_RESULT_SUBTYPE 0x001000000)
 (def SQLITE_SELFORDER1 0x002000000)
+(def SQLITE_CONFIG_MEMSTATUS 9)
 
 (defn copy-resource [resource-path output-path]
   (with-open [in  (io/input-stream (io/resource resource-path))
@@ -69,7 +70,36 @@
   sqlite3_initialize
   [] ::mem/int)
 
-(defonce init-lib (initialize))
+;; sqlite3_config is variadic in C; for SQLITE_CONFIG_MEMSTATUS the trailing
+;; argument is a single int. Declaring as (int, int) -> int works on the
+;; supported platforms (x86_64 + aarch64 on Linux/macOS) for this signature.
+(defcfn config-int
+  sqlite3_config
+  [::mem/int ::mem/int] ::mem/int)
+
+(defcfn memory-used
+  "Bytes currently allocated by SQLite globally in this process.
+  Returns 0 unless memstatus is enabled (see -Dsqlite4clj.memstatus=true)."
+  sqlite3_memory_used
+  [] ::mem/long)
+
+(defcfn memory-highwater
+  "High-water mark in bytes of SQLite's global allocator since process start
+  (or since the last reset). Pass reset?=1 to reset the high-water mark.
+  Returns 0 unless memstatus is enabled (see -Dsqlite4clj.memstatus=true)."
+  sqlite3_memory_highwater
+  [::mem/int] ::mem/long)
+
+;; SQLite's bundled binaries are built with SQLITE_DEFAULT_MEMSTATUS=0 so the
+;; sqlite3_memory_used / sqlite3_memory_highwater counters are no-ops by
+;; default (returning 0). Setting -Dsqlite4clj.memstatus=true enables them at
+;; the cost of one extra atomic increment per allocation. Must be configured
+;; before sqlite3_initialize, so we do it here just before init-lib runs.
+(defonce init-lib
+  (do
+    (when (= "true" (System/getProperty "sqlite4clj.memstatus"))
+      (config-int SQLITE_CONFIG_MEMSTATUS 1))
+    (initialize)))
 
 (defcfn free
   sqlite3_free


### PR DESCRIPTION
## Why

The bundled SQLite binaries are built with `SQLITE_DEFAULT_MEMSTATUS=0` (visible in `pragma compile_options`), so `sqlite3_memory_used()` and `sqlite3_memory_highwater()` always return 0. This makes it impossible to observe SQLite's off-heap memory footprint from the JVM:

- per-connection page caches (governed by `PRAGMA cache_size`)
- per-connection prepared-statement caches (the `:threshold 512` FIFO cache in `sqlite4clj.core/new-conn!`)
- `temp_store=MEMORY` allocations during `ORDER BY`/`GROUP BY`/sorts

None of these show up in JVM heap dumps. We hit a Linux OOM-kill on a 16 GB box recently and only after reading the SQLite docs realized why `sqlite3_memory_used` reported zero — the bundled lib has memstatus disabled at compile time.

## What

Adds an opt-in switch via system property:

```
-Dsqlite4clj.memstatus=true
```

When set, `sqlite3_config(SQLITE_CONFIG_MEMSTATUS, 1)` is called just before `sqlite3_initialize` on first ns load. Per [SQLite's docs](https://www.sqlite.org/c3ref/c_config_covering_index_scan.html#sqliteconfigmemstatus), the cost is one extra atomic increment per allocation — measurable but tiny.

Two public functions added to `sqlite4clj.core`:

```clojure
(memory-used)                 ;; long, bytes currently allocated by SQLite
(memory-highwater)            ;; long, highwater since process start
(memory-highwater true)       ;; read-and-reset the highwater
```

When the property is unset, both return 0 (matches existing behavior — no breakage).

## Design choice

Picked the `-D` system-property pattern to mirror the existing `sqlite4clj.native-lib` convention rather than:

- enabling memstatus by default (would impose the perf hit on everyone)
- exposing an `(enable-memstatus!)` function (forces correct ordering on the user — must run before any `init-db!`)
- rebuilding the bundled `.so` files with `SQLITE_DEFAULT_MEMSTATUS=1` (locks in the choice; requires zig + binary commits)

Happy to refactor to any of those if you'd prefer.

## Verification

- `bb test` — all 18 tests, 71 assertions pass with no changes
- Smoke test: with `-Dsqlite4clj.memstatus=true`, `(memory-used)` returns real growing numbers as a DB is opened and rows are inserted; without the property, returns 0

## Notes

- Picked SQLite constant `SQLITE_CONFIG_MEMSTATUS = 9` from the [official sqlite3.h](https://github.com/sqlite/sqlite/blob/master/src/sqlite.h.in)
- `sqlite3_config` is variadic in C; declaring it as `(int, int) -> int` works on the supported platforms (x86_64 + aarch64 on Linux/macOS) for this 2-int signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)