### PR TITLE
Defensive: warmup write-tx so read-only reader pool can attach to a fresh WAL DB

### DIFF
--- a/src/sqlite4clj/core.clj
+++ b/src/sqlite4clj/core.clj
@@ -224,14 +224,24 @@
            :pragma    (merge pragma writer-pragma)
            :vfs       vfs
            :default-result-set-fn default-result-set-fn})
-        ;; Force -wal/-shm files to materialize before opening the
-        ;; read-only reader pool.  On a fresh WAL database, the writer
+        ;; Defensive: force -wal/-shm files to materialize before opening
+        ;; the read-only reader pool.  On a fresh WAL database the writer
         ;; pool sets journal_mode=WAL but no -shm/-wal files exist yet
-        ;; (no write has happened).  The read-only reader pool then
-        ;; cannot create them, and pragmas like cache_size fail with
-        ;; SQLITE_CANTOPEN ("unable to open database file").  A no-op
-        ;; write transaction here creates -wal/-shm so the reader can
-        ;; attach.
+        ;; (no write has happened).  Per SQLite WAL docs §5, a
+        ;; SQLITE_OPEN_READONLY connection can attach to a WAL DB only if
+        ;; -shm/-wal already exist or the database is opened immutable.
+        ;; macOS's stock sqlite3 3.51.0 demonstrates this deterministically:
+        ;;
+        ;;   $ sqlite3 fresh.db "PRAGMA journal_mode=WAL;"
+        ;;   $ sqlite3 -readonly fresh.db "PRAGMA cache_size=15625;"
+        ;;   Error: in prepare, unable to open database file (14)
+        ;;
+        ;; The bundled SQLite 3.51.3 in this library is more permissive in
+        ;; isolated tests, but the failure has been observed in production
+        ;; on macOS — likely a timing/VFS interaction that does not
+        ;; reliably reproduce in a fresh JVM.  A no-op write tx here is
+        ;; the cheapest way to satisfy the docs' condition (1) regardless
+        ;; of which SQLite/OS quirks are in play.
         _ (when-not (= ":memory:" url)
             (let [conn-pool (:conn-pool writer)
                   conn      (BlockingQueue/.take conn-pool)]

--- a/src/sqlite4clj/core.clj
+++ b/src/sqlite4clj/core.clj
@@ -224,6 +224,22 @@
            :pragma    (merge pragma writer-pragma)
            :vfs       vfs
            :default-result-set-fn default-result-set-fn})
+        ;; Force -wal/-shm files to materialize before opening the
+        ;; read-only reader pool.  On a fresh WAL database, the writer
+        ;; pool sets journal_mode=WAL but no -shm/-wal files exist yet
+        ;; (no write has happened).  The read-only reader pool then
+        ;; cannot create them, and pragmas like cache_size fail with
+        ;; SQLITE_CANTOPEN ("unable to open database file").  A no-op
+        ;; write transaction here creates -wal/-shm so the reader can
+        ;; attach.
+        _ (when-not (= ":memory:" url)
+            (let [conn-pool (:conn-pool writer)
+                  conn      (BlockingQueue/.take conn-pool)]
+              (try
+                (q* conn ["BEGIN IMMEDIATE"] default-result-set-fn)
+                (q* conn ["COMMIT"] default-result-set-fn)
+                (finally
+                  (BlockingQueue/.offer conn-pool conn)))))
         ;; Pool of read connections
         reader (if (= ":memory:" url)
                  writer

--- a/test/sqlite4clj/core_test.clj
+++ b/test/sqlite4clj/core_test.clj
@@ -124,3 +124,21 @@
                                ["select length(data) from raw_bytes where id = 1"])]
           (is (= (seq payload) (seq stored-bytes)))
           (is (= (inc (alength payload)) stored-length)))))))
+
+(deftest init-db-on-fresh-wal-database
+  (testing "init-db! succeeds on a brand-new file with default WAL pragmas.
+
+  Regression: without a write-tx warmup between writer and reader pool init,
+  the read-only reader pool could not attach to a fresh WAL database (no
+  -shm/-wal files exist yet, and a read-only connection cannot create them),
+  causing pragmas like cache_size to fail with SQLITE_CANTOPEN."
+    (let [path "test-data/fresh-wal.db"]
+      (clojure.java.io/delete-file (clojure.java.io/file path) true)
+      (clojure.java.io/delete-file (clojure.java.io/file (str path "-shm")) true)
+      (clojure.java.io/delete-file (clojure.java.io/file (str path "-wal")) true)
+      (with-db [db (d/init-db! path {:pool-size 2})]
+        (is (some? (:writer db)))
+        (is (some? (:reader db)))
+        (d/q (:writer db) ["CREATE TABLE t (x INT)"])
+        (d/q (:writer db) ["INSERT INTO t VALUES (1)"])
+        (is (= [1] (d/q (:reader db) ["SELECT x FROM t"])))))))

--- a/test/sqlite4clj/core_test.clj
+++ b/test/sqlite4clj/core_test.clj
@@ -126,12 +126,14 @@
           (is (= (inc (alength payload)) stored-length)))))))
 
 (deftest init-db-on-fresh-wal-database
-  (testing "init-db! succeeds on a brand-new file with default WAL pragmas.
+  (testing "init-db! works on a brand-new file with default WAL pragmas.
 
-  Regression: without a write-tx warmup between writer and reader pool init,
-  the read-only reader pool could not attach to a fresh WAL database (no
-  -shm/-wal files exist yet, and a read-only connection cannot create them),
-  causing pragmas like cache_size to fail with SQLITE_CANTOPEN."
+  This is a smoke test, not a strict regression test: the fresh-WAL failure
+  this change defends against (see the comment in init-db!) does not
+  reliably reproduce against the bundled SQLite in a fresh JVM, even though
+  it has been observed in production on macOS and is reproducible at the
+  SQLite CLI level (3.51.0).  This test just verifies that the warmup tx
+  doesn't break the normal happy path."
     (let [path "test-data/fresh-wal.db"]
       (clojure.java.io/delete-file (clojure.java.io/file path) true)
       (clojure.java.io/delete-file (clojure.java.io/file (str path "-shm")) true)


### PR DESCRIPTION
## Update — please re-read; I revised this PR after my colleague pointed out my original claims were overstated.

This is a **defensive fix** for a macOS-specific failure mode in `init-db!`, not a fully-reproducible bug fix. Here's what I actually know:

## The underlying SQLite behavior is real

Per [SQLite WAL docs §5](https://www.sqlite.org/wal.html#read_only_databases), a `SQLITE_OPEN_READONLY` connection can attach to a WAL database only if **one of**:

1. The `-shm` and `-wal` files already exist and are readable, *or*
2. There is write permission on the directory and SQLite can create them, *or*
3. The connection uses the `immutable` URI parameter.

For sqlite4clj's reader pool: the connection is opened with literal `SQLITE_OPEN_READONLY` (`0x1`) and no `immutable=1`, so condition (3) doesn't apply. Condition (2) only applies to scenarios where the *file itself* is read-only and SQlite is opening it R/W; with an explicit `SQLITE_OPEN_READONLY` flag, SQLite respects the read-only contract and refuses to create files. That leaves condition (1).

After the writer pool runs `pragma journal_mode=WAL` but no transaction has occurred, the `-shm`/`-wal` files **do not exist on disk**. So none of the three conditions are satisfied → `SQLITE_CANTOPEN`.

## Reproduces deterministically at the SQLite CLI level on macOS

```
$ sqlite3 /tmp/wal.db "PRAGMA journal_mode=WAL;"
   wal
$ ls /tmp/wal.db*
   /tmp/wal.db                 (no -wal, no -shm)
$ sqlite3 -readonly /tmp/wal.db "PRAGMA cache_size=15625;"
   Error: in prepare, unable to open database file (14)
$ sqlite3 /tmp/wal.db "BEGIN IMMEDIATE; COMMIT;"
$ sqlite3 -readonly /tmp/wal.db "PRAGMA cache_size=15625;"
   (no error)
```

(Tested against Apple's bundled `sqlite3 3.51.0` on macOS Sequoia.)

## I cannot reproduce it deterministically against this library's bundled SQLite (3.51.3) in a fresh JVM

This is the part where I was wrong in my original PR. I tried many variants — different paths, pool sizes, leftover `-shm`/`-wal`, closed-then-reopened writer, concurrent load, the `-Dsqlite4clj.memstatus=true` flag — and got `:ok` every time. Bundled 3.51.3 appears more permissive than the system 3.51.0.

## But it has bitten a real production system on macOS

A user running this library on macOS hit this exact stack trace in `app.log`:

```
clojure.lang.ExceptionInfo: SQLite error: unable to open database file
                            unable to open database file
  code: "unable to open database file"
  message: "unable to open database file"
  sql: "pragma cache_size=15625"
... sqlite4clj.core/init-db!         core.clj: 211
    sqlite4clj.core/init-db!         core.clj: 230
    sqlite4clj.core/init-pool!       core.clj: 190
    sqlite4clj.core/init-pool!       core.clj: 198
    sqlite4clj.core/new-conn!        core.clj: 187
```

A colleague separately reports being able to reproduce something on macOS but not on Linux, which is consistent with macOS's SQLite VFS layer (different from Linux's) being the source of the variability.

## Why I still think the patch is worth merging

- The fix is **a single tiny no-op transaction per `init-db!` call**, once per database lifetime. Cost is negligible and only paid at init time.
- It **cannot make any working case worse** — it just satisfies docs condition (1) earlier.
- It **completely defuses** the documented WAL+readonly constraint, regardless of which macOS-specific quirk is responsible for triggering the failure in production.
- Linux users are unaffected (the bug doesn't appear there per my colleague's testing, and the warmup is still a no-op write).

If you'd rather wait for someone to produce a deterministic minimal repro against the bundled library, that's a fair call to make and I won't push back. I just want to be honest about what I do and don't know about this.

## Changes

- `src/sqlite4clj/core.clj`: between the writer-pool init and the reader-pool init, run `BEGIN IMMEDIATE; COMMIT` on the writer connection (skipped for `:memory:` databases). Comment explains the rationale.
- `test/sqlite4clj/core_test.clj`: a smoke test verifying `init-db!` still works on a fresh WAL file. (NOT a strict regression test — it passes on the unpatched library too. Docstring says so.)

All 19 existing tests still pass (74 assertions, 0 failures).