### PR TITLE
Extract the bundled native library to a unique temporary file

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ Bundled in the classpath is pre-built libsqlite3 shared library for:
 If you want to provide your own native library then specify the `sqlite4clj.native-lib` system property:
 
 - `-Dsqlite4clj.native-lib=bundled`, uses the pre-built library (default if property is omitted)
+  The bundled library is extracted to a unique temporary file under `java.io.tmpdir` and deleted after it loads.
 - `-Dsqlite4clj.native-lib=system`, loads the sqlite3 library from the `java.library.path` (which includes `LD_LIBRARY_PATH`)
 - `-Dsqlite4clj.native-lib=/path/to/libsqlite3.so`, the value is interpreted as a path to a file that is loaded directly
 

--- a/src/sqlite4clj/impl/api.clj
+++ b/src/sqlite4clj/impl/api.clj
@@ -9,6 +9,7 @@
    [sqlite4clj.impl.ffi-wrapper :as ffi-wrapper :refer [defcfn]])
   (:import
    [java.nio.file Files]
+   [java.nio.file.attribute FileAttribute]
    [java.lang.foreign MemorySegment]))
 
 (set! *warn-on-reflection* true)
@@ -48,11 +49,16 @@
           ("x86-windows"
            "x86_64-windows"
            "amd64-windows") "sqlite3_x86_64-windows-gnu.dll")
-        temp-lib-filename (str "sqlite4clj_temp_" res-file)]
-    (copy-resource res-file temp-lib-filename)
-    (ffi-wrapper/set-library! temp-lib-filename)
-    ;; We delete once loaded
-    (Files/deleteIfExists (.toPath (io/file temp-lib-filename)))))
+        ;; One file per process. Concurrent JVMs must never share the inode
+        ;; that the dynamic linker maps.
+        temp-lib (Files/createTempFile "sqlite4clj_" (str "_" res-file)
+                   (make-array FileAttribute 0))]
+    (try
+      (copy-resource res-file (str temp-lib))
+      (ffi-wrapper/set-library! (str temp-lib))
+      (finally
+        ;; The mapping outlives the directory entry.
+        (Files/deleteIfExists temp-lib)))))
 
 (defn load-system-library []
   (ffi/load-system-library "sqlite3"))


### PR DESCRIPTION
## Problem

The bundled-library loader writes to the fixed relative filename `sqlite4clj_temp_<platform-library>` in the process working directory. `io/output-stream` truncates an existing file in place, without changing its inode. Concurrent JVMs can therefore truncate and rewrite the same inode while another JVM maps it through `dlopen` or resolves symbols through `dlsym`. One JVM can also unlink the path before another calls `dlopen`.

Observed failure signatures on Linux (Temurin 26+35, glibc 2.44):

- `SIGSEGV` in `dlsym`, under `NativeLibrary.findEntry0`, while loading `sqlite4clj.impl.api`.
- `SIGBUS` in `dlopen`, under `RawNativeLibraries.load0`.
- `IllegalArgumentException: Cannot open library: .../sqlite4clj_temp_...`.

## Change

Use `Files/createTempFile` to create a unique file under `java.io.tmpdir`. Keep the platform library filename as the suffix. Copy and load that file, then remove it in `finally`, including when loading fails. Each loader invocation owns a separate inode; nothing is written to the working directory.

The architecture mapping, bundled binaries, SQLite build options, system-library loading, and `sqlite4clj.native-lib` dispatch are unchanged. README documents the temporary-file behavior.

## Verification

The reproduction starts 16 JVMs in one scratch working directory. Each preloads the loader dependencies, waits on a shared barrier, then requires `sqlite4clj.impl.api`. Only the native loader crash signatures above and the fixed-path open failure count as race evidence.

- Upstream `f1224bbe701533605f30c9ffbe0e2a6a0b7c085a`, 3 rounds: 48 processes; one confirmed race-open failure. A separate `ld.so` relocation assertion was classified as `other` and excluded from the confirming count.
- Fixed commit `172649d1315fd2accc73bd08d5519e23a60b4c50`, 5 rounds: 80 processes, zero failures of any class. No `sqlite4clj_*` file remained in the scratch directory or `java.io.tmpdir` (`/tmp`).
- Kaocha: 21 tests, 78 assertions, 0 failures. The suite used a command-line alias with the same source/test paths and native-access/timezone options, because JDK 26 rejects the existing dev alias's `-XX:+ZGenerational` option. No dependency or task file changed.
- After importing clj-kondo hooks, lint before and after has the same one pre-existing `column-blob` type error and two `session.clj` warnings; no new finding.
- Runtime smoke: native symbol lookup succeeds from the unique temporary file. A forced load failure propagates and still removes the file.
