### PR TITLE
refactor from coffi -> babashka/ffi

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,3 +1,3 @@
 {:hooks
  {:analyze-call
-  {sqlite4clj.impl.ffi-wrapper/defcfn hooks.coffi/defcfn}}}
+  {sqlite4clj.impl.ffi-wrapper/defcfn hooks.babashka.ffi/defcfn}}}

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Conceptually sqlite4clj is inspired by sqlite4java a sqlite library that doesn't use the JDBC interface. The goal of sqlite4clj is to have a minimalist FFI binding to SQLite's C API using Java 22 FFI (project panama). Tighter integration with SQLite can in theory offer better performance and features not available through JDBC interfaces.
 
-By using [coffi](https://github.com/IGJoshua/coffi) to interface with SQLite's C API directly with FFI we bypass the need for: [sqlite-jdbc](https://github.com/xerial/sqlite-jdbc), [hikariCP](https://github.com/brettwooldridge/HikariCP) and [next.jdbc](https://github.com/seancorfield/next-jdbc). This massively reduces the amount of code that needs to be maintained (and a much smaller jar), allows us to use Clojure to interface with SQLite directly. It also makes it easier to add SQLite specific features. In my case I was looking to cache prepared statement for each connection (which is not possible with HikariCP) but can lead to considerable performance gains on complex queries.
+By using [babashka/ffi](https://github.com/babashka/ffi) to interface with SQLite's C API directly with FFI we bypass the need for: [sqlite-jdbc](https://github.com/xerial/sqlite-jdbc), [hikariCP](https://github.com/brettwooldridge/HikariCP) and [next.jdbc](https://github.com/seancorfield/next-jdbc). This massively reduces the amount of code that needs to be maintained (and a much smaller jar), allows us to use Clojure to interface with SQLite directly. It also makes it easier to add SQLite specific features. In my case I was looking to cache prepared statement for each connection (which is not possible with HikariCP) but can lead to considerable performance gains on complex queries.
 
 This also frees up scope for common things like binary encoding and decoding to leverage SQLite's blob type.
 
@@ -12,7 +12,7 @@ Currently, this project is very much a proof of concept. But, I'm hoping to ulti
 
 ## Usage
 
-Currently this library is not on maven so you have to add it via git deps (note: coffi requires at least Java 22):
+Currently this library is not on maven so you have to add it via git deps (note: babashka/ffi requires at least Java 22 and the JVM option `--enable-native-access=ALL-UNNAMED`):
 
 ```clojure
 andersmurphy/sqlite4clj

--- a/deps.edn
+++ b/deps.edn
@@ -1,8 +1,7 @@
 {:paths   ["src" "resources"]
  :deps    {org.clojure/clojure       {:mvn/version "1.12.0"}
-           org.suskalo/coffi
-           {:git/url "https://github.com/IGJoshua/coffi"
-            :git/sha "03d74aedecfc7b38238f1cf8b676c1f7a00e1788"}
+           babashka/ffi              {:git/url "https://github.com/babashka/ffi"
+                                      :git/sha "062a653a743a1f1dcb05f3545d22d27011edfc3d"}
            org.clojure/core.cache    {:mvn/version "1.1.234"}
            io.github.tonsky/fast-edn {:mvn/version "1.1.3"}}
  :aliases {:dev    {:extra-paths ["dev" "test"]

--- a/src/sqlite4clj/impl/api.clj
+++ b/src/sqlite4clj/impl/api.clj
@@ -252,11 +252,10 @@
   [:pointer :int] :pointer
   sqlite3_column_blob-native
   [stmt idx]
-  (with-open [arena (ffi/confined-arena)]
-    (let [result (sqlite3_column_blob-native stmt idx)
-          size   (column-bytes stmt idx)
-          blob   (ffi/reinterpret result size arena)]
-      (enc/decode blob size))))
+  (let [result (sqlite3_column_blob-native stmt idx)
+        size   (column-bytes stmt idx)
+        blob   (ffi/reinterpret result size)]
+    (enc/decode blob size)))
 
 (defcfn column-type
   "sqlite3_column_type"
@@ -311,10 +310,9 @@
   (let [result (sqlite3-value-blob-native sqlite-value)]
     (if (ffi/null? result)
       nil
-      (with-open [arena (ffi/confined-arena)]
-        (let [^int size (value-bytes sqlite-value)
-              blob      (ffi/reinterpret result size arena)]
-          (enc/decode blob size))))))
+      (let [^int size (value-bytes sqlite-value)
+            blob      (ffi/reinterpret result size)]
+        (enc/decode blob size)))))
 
 (defcfn result-text
   "sqlite3_result_text"

--- a/src/sqlite4clj/impl/api.clj
+++ b/src/sqlite4clj/impl/api.clj
@@ -1,10 +1,9 @@
 (ns sqlite4clj.impl.api
   "These function map directly to SQLite's C API."
   (:require
+   [babashka.ffi :as ffi]
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [coffi.ffi :as ffi]
-   [coffi.mem :as mem]
    [sqlite4clj.impl.encoding :as enc]
    [sqlite4clj.impl.ffi-wrapper :as ffi-wrapper :refer [defcfn]])
   (:import
@@ -61,7 +60,17 @@
         (Files/deleteIfExists temp-lib)))))
 
 (defn load-system-library []
-  (ffi/load-system-library "sqlite3"))
+  (let [library-name (System/mapLibraryName "sqlite3")
+        paths        (str/split (System/getProperty "java.library.path" "")
+                       (re-pattern (System/getProperty "path.separator")))
+        library-file (some (fn [path]
+                             (let [file (io/file path library-name)]
+                               (when (.isFile file) file)))
+                       paths)]
+    (reset! ffi-wrapper/lookup_
+      (if library-file
+        (ffi/load-library (.getAbsolutePath ^java.io.File library-file))
+        (ffi/load-system-library "sqlite3")))))
 
 ;; Load appropriate SQLite library
 (let [src (System/getProperty "sqlite4clj.native-lib")]
@@ -74,28 +83,25 @@
     (ffi-wrapper/set-library! src)))
 
 (defcfn initialize
-  sqlite3_initialize
-  [] ::mem/int)
+  "sqlite3_initialize"
+  [] :int)
 
-;; sqlite3_config is variadic in C; for SQLITE_CONFIG_MEMSTATUS the trailing
-;; argument is a single int. Declaring as (int, int) -> int works on the
-;; supported platforms (x86_64 + aarch64 on Linux/macOS) for this signature.
 (defcfn config-int
-  sqlite3_config
-  [::mem/int ::mem/int] ::mem/int)
+  "sqlite3_config"
+  [:int :& :int] :int)
 
 (defcfn memory-used
   "Bytes currently allocated by SQLite globally in this process.
   Returns 0 unless memstatus is enabled (see -Dsqlite4clj.memstatus=true)."
-  sqlite3_memory_used
-  [] ::mem/long)
+  "sqlite3_memory_used"
+  [] :long)
 
 (defcfn memory-highwater
   "High-water mark in bytes of SQLite's global allocator since process start
   (or since the last reset). Pass reset?=1 to reset the high-water mark.
   Returns 0 unless memstatus is enabled (see -Dsqlite4clj.memstatus=true)."
-  sqlite3_memory_highwater
-  [::mem/int] ::mem/long)
+  "sqlite3_memory_highwater"
+  [:int] :long)
 
 ;; SQLite's bundled binaries are built with SQLITE_DEFAULT_MEMSTATUS=0 so the
 ;; sqlite3_memory_used / sqlite3_memory_highwater counters are no-ops by
@@ -105,20 +111,21 @@
 (defonce init-lib
   (do
     (when (= "true" (System/getProperty "sqlite4clj.memstatus"))
+      #_{:clj-kondo/ignore [:invalid-arity]}
       (config-int SQLITE_CONFIG_MEMSTATUS 1))
     (initialize)))
 
 (defcfn free
-  sqlite3_free
-  [::mem/pointer] ::mem/void)
+  "sqlite3_free"
+  [:pointer] :void)
 
 (defcfn errmsg
-  sqlite3_errmsg
-  [::mem/pointer] ::mem/c-string)
+  "sqlite3_errmsg"
+  [:pointer] :string)
 
 (defcfn errstr
-  sqlite3_errstr
-  [::mem/int] ::mem/c-string)
+  "sqlite3_errstr"
+  [:int] :string)
 
 (defn sqlite-ex-info [pdb code data]
   (let [code-name (errstr code)
@@ -132,70 +139,69 @@
   (= code 0))
 
 (defcfn open-v2
-  "sqlite3_open_v2" [::mem/c-string ::mem/pointer ::mem/int
-                     ::mem/c-string] ::mem/int
+  "sqlite3_open_v2" [:string :pointer :int :string] :int
   sqlite3-open-native
   [filename flags vfs]
-  (with-open [arena (mem/confined-arena)]
-    (let [pdb           (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [pdb           (ffi/alloc arena :pointer)
           filename-utf8 (String/new (String/.getBytes filename "UTF-8") "UTF-8")
           vfs-utf8      (when vfs
                           (String/new (String/.getBytes vfs "UTF-8") "UTF-8"))
           code          (sqlite3-open-native filename-utf8
                           pdb flags vfs-utf8)]
       (if (sqlite-ok? code)
-        (mem/deserialize-from pdb ::mem/pointer)
+        (ffi/read pdb :pointer)
         (throw (sqlite-ex-info pdb code {:filename filename}))))))
 
 (defcfn close
-  sqlite3_close
-  [::mem/pointer] ::mem/int)
+  "sqlite3_close"
+  [:pointer] :int)
 
 (defcfn prepare-v3
   "sqlite3_prepare_v3"
-  [::mem/pointer ::mem/c-string ::mem/int
-   ::mem/int
-   ::mem/pointer ::mem/pointer] ::mem/int
+  [:pointer :string :int
+   :int
+   :pointer :pointer] :int
   sqlite3-prepare-native
   [pdb sql]
-  (with-open [arena (mem/confined-arena)]
-    (let [ppStmt (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [ppStmt (ffi/alloc arena :pointer)
           sql    (String/new (String/.getBytes sql "UTF-8") "UTF-8")
           code   (sqlite3-prepare-native pdb sql -1
                    0x01 ;; SQLITE_PREPARE_PERSISTENT
                    ppStmt
                    nil)]
       (if (sqlite-ok? code)
-        (mem/deserialize-from ppStmt ::mem/pointer)
+        (ffi/read ppStmt :pointer)
         (throw (sqlite-ex-info pdb code {:sql sql}))))))
 
 (defcfn reset
-  sqlite3_reset
-  [::mem/pointer] ::mem/int)
+  "sqlite3_reset"
+  [:pointer] :int)
 
 (defcfn clear-bindings
-  sqlite3_clear_bindings
-  [::mem/pointer] ::mem/int)
+  "sqlite3_clear_bindings"
+  [:pointer] :int)
 
 (defcfn bind-int
-  sqlite3_bind_int64
-  [::mem/pointer ::mem/int ::mem/long] ::mem/int)
+  "sqlite3_bind_int64"
+  [:pointer :int :long] :int)
 
 (defcfn bind-double
-  sqlite3_bind_double
-  [::mem/pointer ::mem/int ::mem/double] ::mem/int)
+  "sqlite3_bind_double"
+  [:pointer :int :double] :int)
 
 (defcfn bind-null
-  sqlite3_bind_null
-  [::mem/pointer ::mem/int] ::mem/int)
+  "sqlite3_bind_null"
+  [:pointer :int] :int)
 
-(def sqlite-static (mem/as-segment 0))
-(def sqlite-transient (mem/as-segment -1))
+(def sqlite-static (ffi/segment 0))
+(def sqlite-transient (ffi/segment -1))
 
 (defcfn bind-text
   "sqlite3_bind_text"
-  [::mem/pointer ::mem/int ::mem/c-string ::mem/int
-   ::mem/pointer] ::mem/int
+  [:pointer :int :string :int
+   :pointer] :int
   sqlite3-bind-text-native
   [pdb idx text]
   (let [text       (str text)
@@ -207,112 +213,112 @@
 
 (defcfn bind-blob
   "sqlite3_bind_blob"
-  [::mem/pointer ::mem/int ::mem/pointer ::mem/int
-   ::mem/pointer] ::mem/int
+  [:pointer :int :pointer :int
+   :pointer] :int
   sqlite3-bind-blob-native
   [pdb idx blob]
-  (with-open [arena (mem/confined-arena)]
+  (with-open [arena (ffi/confined-arena)]
     (let [segment (enc/encode arena blob)]
       (sqlite3-bind-blob-native pdb idx segment
         (MemorySegment/.byteSize segment)
         sqlite-transient))))
 
 (defcfn step
-  sqlite3_step
-  [::mem/pointer] ::mem/int)
+  "sqlite3_step"
+  [:pointer] :int)
 
 (defcfn column-count
-  sqlite3_column_count
-  [::mem/pointer] ::mem/int)
+  "sqlite3_column_count"
+  [:pointer] :int)
 
 (defcfn column-double
-  sqlite3_column_double
-  [::mem/pointer ::mem/int] ::mem/double)
+  "sqlite3_column_double"
+  [:pointer :int] :double)
 
 (defcfn column-int
-  sqlite3_column_int64
-  [::mem/pointer ::mem/int] ::mem/long)
+  "sqlite3_column_int64"
+  [:pointer :int] :long)
 
 (defcfn column-text
-  sqlite3_column_text
-  [::mem/pointer ::mem/int] ::mem/c-string)
+  "sqlite3_column_text"
+  [:pointer :int] :string)
 
 (defcfn column-bytes
-  sqlite3_column_bytes
-  [::mem/pointer ::mem/int] ::mem/int)
+  "sqlite3_column_bytes"
+  [:pointer :int] :int)
 
 (defcfn column-blob
   "sqlite3_column_blob"
-  [::mem/pointer ::mem/int] ::mem/pointer
+  [:pointer :int] :pointer
   sqlite3_column_blob-native
   [stmt idx]
-  (with-open [arena (mem/confined-arena)]
+  (with-open [arena (ffi/confined-arena)]
     (let [result (sqlite3_column_blob-native stmt idx)
           size   (column-bytes stmt idx)
-          blob   (mem/reinterpret result size arena)]
+          blob   (ffi/reinterpret result size arena)]
       (enc/decode blob size))))
 
 (defcfn column-type
-  sqlite3_column_type
-  [::mem/pointer ::mem/int] ::mem/int)
+  "sqlite3_column_type"
+  [:pointer :int] :int)
 
 (defcfn finalize
-  sqlite3_finalize
-  [::mem/pointer] ::mem/int)
+  "sqlite3_finalize"
+  [:pointer] :int)
 
 (defcfn create-function-v2
-  sqlite3_create_function_v2
-  [::mem/pointer  ;; db
-   ::mem/c-string ;; zFunctionName
-   ::mem/int      ;; nArg
-   ::mem/int      ;; eTextRep (includes flags)
-   ::mem/pointer  ;; pApp (user data)
-   ::mem/pointer  ;; xFunc (function pointer, not inline definition)
-   ::mem/pointer  ;; xStep (for aggregates)
-   ::mem/pointer  ;; xFinal (for aggregates)
-   ::mem/pointer] ;; xDestroy (destructor)
-  ::mem/int)
+  "sqlite3_create_function_v2"
+  [:pointer  ;; db
+   :string   ;; zFunctionName
+   :int      ;; nArg
+   :int      ;; eTextRep (includes flags)
+   :pointer  ;; pApp (user data)
+   :pointer  ;; xFunc (function pointer, not inline definition)
+   :pointer  ;; xStep (for aggregates)
+   :pointer  ;; xFinal (for aggregates)
+   :pointer] ;; xDestroy (destructor)
+  :int)
 
 (defcfn aggregate-context
-  sqlite3_aggregate_context
-  [::mem/pointer ::mem/int] ::mem/pointer)
+  "sqlite3_aggregate_context"
+  [:pointer :int] :pointer)
 
 (defcfn value-text
-  sqlite3_value_text
-  [::mem/pointer] ::mem/c-string)
+  "sqlite3_value_text"
+  [:pointer] :string)
 
 (defcfn value-int
-  sqlite3_value_int64
-  [::mem/pointer] ::mem/long)
+  "sqlite3_value_int64"
+  [:pointer] :long)
 
 (defcfn value-double
-  sqlite3_value_double
-  [::mem/pointer] ::mem/double)
+  "sqlite3_value_double"
+  [:pointer] :double)
 
 (defcfn value-type
-  sqlite3_value_type
-  [::mem/pointer] ::mem/int)
+  "sqlite3_value_type"
+  [:pointer] :int)
 
 (defcfn value-bytes
-  sqlite3_value_bytes
-  [::mem/pointer] ::mem/int)
+  "sqlite3_value_bytes"
+  [:pointer] :int)
 
 (defcfn value-blob
   "sqlite3_value_blob"
-  [::mem/pointer] ::mem/pointer
+  [:pointer] :pointer
   sqlite3-value-blob-native
   [sqlite-value]
   (let [result (sqlite3-value-blob-native sqlite-value)]
-    (if (mem/null? result)
+    (if (ffi/null? result)
       nil
-      (with-open [arena (mem/confined-arena)]
+      (with-open [arena (ffi/confined-arena)]
         (let [^int size (value-bytes sqlite-value)
-              blob      (mem/reinterpret result size arena)]
+              blob      (ffi/reinterpret result size arena)]
           (enc/decode blob size))))))
 
 (defcfn result-text
   "sqlite3_result_text"
-  [::mem/pointer ::mem/c-string ::mem/int ::mem/pointer] ::mem/void
+  [:pointer :string :int :pointer] :void
   sqlite3-result-text-native
   [context text]
   (let [text-bytes (String/.getBytes (str text) "UTF-8")]
@@ -322,16 +328,16 @@
       sqlite-transient)))
 
 (defcfn result-int
-  sqlite3_result_int64
-  [::mem/pointer ::mem/long] ::mem/void)
+  "sqlite3_result_int64"
+  [:pointer :long] :void)
 
 (defcfn result-double
-  sqlite3_result_double
-  [::mem/pointer ::mem/double] ::mem/void)
+  "sqlite3_result_double"
+  [:pointer :double] :void)
 
 (defcfn result-null
   "sqlite3_result_null"
-  [::mem/pointer] ::mem/void
+  [:pointer] :void
   sqlite3-result-null-native
   ([context]
    (sqlite3-result-null-native context))
@@ -340,17 +346,17 @@
 
 (defcfn result-blob
   "sqlite3_result_blob"
-  [::mem/pointer ::mem/pointer ::mem/int ::mem/pointer] ::mem/void
+  [:pointer :pointer :int :pointer] :void
   sqlite3-result-blob-native
   [context blob]
-  (with-open [arena (mem/confined-arena)]
+  (with-open [arena (ffi/confined-arena)]
     (let [segment   (enc/encode arena blob)]
     (sqlite3-result-blob-native context
       segment (MemorySegment/.byteSize segment) sqlite-transient))))
 
 (defcfn result-error
   "sqlite3_result_error"
-  [::mem/pointer ::mem/c-string ::mem/int] ::mem/void
+  [:pointer :string :int] :void
   sqlite3-result-error-native
   [context msg]
   (let [msg       (str msg)
@@ -360,36 +366,36 @@
       (count msg-bytes))))
 
 (defcfn column-database-name
-  sqlite3_column_database_name
-  [::mem/pointer ::mem/int] ::mem/c-string)
+  "sqlite3_column_database_name"
+  [:pointer :int] :string)
 
 (defcfn column-table-name
-  sqlite3_column_table_name
-  [::mem/pointer ::mem/int] ::mem/c-string)
+  "sqlite3_column_table_name"
+  [:pointer :int] :string)
 
 (defcfn column-origin-name
-  sqlite3_column_origin_name
-  [::mem/pointer ::mem/int] ::mem/c-string)
+  "sqlite3_column_origin_name"
+  [:pointer :int] :string)
 
 (defcfn column-name
   ;; The name of a result column is the value of the "AS" clause for that
   ;; column, if there is an AS clause. If there is no AS clause then the
   ;; name of the column is unspecified and may change from one release of
   ;; SQLite to the next.
-  sqlite3_column_name
-  [::mem/pointer ::mem/int] ::mem/c-string)
+  "sqlite3_column_name"
+  [:pointer :int] :string)
 
 (defcfn sqlite3-limit
   "https://sqlite.org/c3ref/limit.html"
-  sqlite3_limit
-  [::mem/pointer ::mem/int ::mem/int] ::mem/int)
+  "sqlite3_limit"
+  [:pointer :int :int] :int)
 
 (defcfn sqlite3-interrupt
-  "https://sqlite.org/c3ref/interrupt.html"  
-  sqlite3_interrupt
-  [::mem/pointer] ::mem/int)
+  "https://sqlite.org/c3ref/interrupt.html"
+  "sqlite3_interrupt"
+  [:pointer] :void)
 
 (defcfn sqlite3-is-interrupted
   "https://sqlite.org/c3ref/interrupt.html"
-  sqlite3_is_interrupted
-  [::mem/pointer] ::mem/int)
+  "sqlite3_is_interrupted"
+  [:pointer] :int)

--- a/src/sqlite4clj/impl/encoding.clj
+++ b/src/sqlite4clj/impl/encoding.clj
@@ -1,5 +1,5 @@
 (ns sqlite4clj.impl.encoding
-  (:require [coffi.mem :as mem]
+  (:require [babashka.ffi :as ffi]
             [fast-edn.core :as edn])
   (:import [java.lang.foreign MemorySegment SegmentAllocator]))
 
@@ -12,7 +12,7 @@
   ;; Read exactly `size` bytes from the BLOB payload. Relying on C-string
   ;; null terminators can leak random trailing bytes into EDN decoding.
   (edn/read-string
-    (String. (.toArray (mem/slice blob 0 size)
+    (String. (.toArray (ffi/slice blob 0 size)
                java.lang.foreign.ValueLayout/JAVA_BYTE)
       "UTF-8")))
 
@@ -27,15 +27,15 @@
         b-l          (alength ^bytes b)
         total        (unchecked-inc-int b-l)
         segment      (SegmentAllocator/.allocate arena (long total))]
-    (mem/write-byte segment leading-byte)
-    (mem/write-bytes segment b-l 1 ^bytes b)
+    (ffi/write segment :byte leading-byte)
+    (ffi/write-array segment :byte b 1)
     segment))
 
 (defn decode [blob size]
   (if (pos? size)
     ;; case does not work with bytes!
-    (let [f-byte (mem/read-byte blob)
-          blob   (mem/slice blob 1)]
+    (let [f-byte (ffi/read blob :byte)
+          blob   (ffi/slice blob 1)]
       (if (= f-byte ENCODED_BLOB)
         (decode-edn blob (dec size))
         ;; Otherwise

--- a/src/sqlite4clj/impl/ffi_wrapper.clj
+++ b/src/sqlite4clj/impl/ffi_wrapper.clj
@@ -1,24 +1,17 @@
 (ns sqlite4clj.impl.ffi-wrapper
-  (:require [coffi.ffi :as ffi]
-            [clojure.java.io :as io])
-  (:import [java.lang.foreign Arena SymbolLookup]))
-
-(defonce ^Arena sqlite-lookup-arena
-  (Arena/global))
+  (:require [babashka.ffi :as ffi]
+            [clojure.java.io :as io]))
 
 (def lookup_ (atom nil))
 
 (defn set-library! [file-name]
   (reset! lookup_
-    (when file-name
-      (SymbolLookup/libraryLookup (.getAbsolutePath (io/file file-name))
-        sqlite-lookup-arena))))
+          (when file-name
+            (ffi/load-library (.getAbsolutePath (io/file file-name))))))
 
- (defn find-symbol [sym]
-  (if-let [^SymbolLookup lookup @lookup_]
-    (-> lookup (.find (name sym)) (.orElse nil))
-    (ffi/find-symbol sym)))
-
-(defmacro defcfn [& args]
-  `(with-redefs [coffi.ffi/find-symbol find-symbol]
-     (coffi.ffi/defcfn ~@args)))
+(defmacro defcfn [name & args]
+  (let [[doc args] (if (and (string? (first args))
+                            (not (vector? (second args))))
+                     [[(first args)] (next args)]
+                     [nil args])]
+    `(ffi/defcfn ~name ~@doc {:library lookup_} ~@args)))

--- a/src/sqlite4clj/impl/functions.clj
+++ b/src/sqlite4clj/impl/functions.clj
@@ -1,7 +1,6 @@
 (ns sqlite4clj.impl.functions
   (:require
-   [coffi.ffi :as ffi]
-   [coffi.mem :as mem]
+   [babashka.ffi :as ffi]
    [sqlite4clj.impl.api :as api])
   (:import
    [java.lang.reflect Method]))
@@ -66,15 +65,15 @@
 (defn deserialize-argv
   "Extract sqlite3_value pointers from argv array"
   [argv argc]
-  (if (or (mem/null? argv) (zero? argc))
+  (if (or (ffi/null? argv) (zero? argc))
     []
     (let [;; Reinterpret argv as an array of pointers with the correct size
           argc-int     (int argc)
-          ptr-size     8
-          argv-segment (mem/reinterpret argv (* argc-int ptr-size))]
+          ptr-size     (ffi/sizeof :pointer)
+          argv-segment (ffi/reinterpret argv (* argc-int ptr-size))]
       (mapv (fn [i]
               ;; Read each pointer from the array
-              (mem/read-address argv-segment ^long (* i ptr-size)))
+              (ffi/read argv-segment :pointer (* i ptr-size)))
         (range argc-int)))))
 
 (defn value->clj
@@ -116,8 +115,8 @@
     (fn [conn]
       (let [pdb  (:pdb conn)
             ;; "To delete an existing SQL function or aggregate, pass NULL pointers for all three function callbacks."
-            code (api/create-function-v2 pdb name arity flags mem/null
-                   mem/null mem/null mem/null mem/null)]
+            code (api/create-function-v2 pdb name arity flags ffi/null
+                   ffi/null ffi/null ffi/null ffi/null)]
         (when-not (api/sqlite-ok? code)
           (throw (api/sqlite-ex-info pdb code {:function name})))))))
 
@@ -174,17 +173,13 @@
             (fn [n]
               (let [arity        (if (= n :variadic) -1 n)
                     callback     (wrap-scalar-function f)
-                    callback-ptr (mem/serialize callback
-                                   [::ffi/fn
-                                    [::mem/pointer ::mem/int ::mem/pointer]
-                                    ::mem/void
-                                    :raw-fn? true]
-                                   (mem/global-arena))]
+                    callback-ptr (ffi/callback (ffi/global-arena) callback
+                                   [:pointer :int :pointer] :void)]
                 (doto-connections db
                   (fn [conn]
                     (let [pdb  (:pdb conn)
-                          code (api/create-function-v2 pdb name arity flags-bitmask mem/null
-                                 callback-ptr mem/null mem/null mem/null)]
+                          code (api/create-function-v2 pdb name arity flags-bitmask ffi/null
+                                 callback-ptr ffi/null ffi/null ffi/null)]
                       (when-not (api/sqlite-ok? code)
                         (throw (api/sqlite-ex-info pdb code {:function name}))))))
                 [arity {:flags        flags-bitmask

--- a/src/sqlite4clj/session.clj
+++ b/src/sqlite4clj/session.clj
@@ -1,10 +1,9 @@
 (ns sqlite4clj.session
   (:require
-   [sqlite4clj.impl.ffi-wrapper :as ffi-wraper :refer [defcfn]]
-   [coffi.ffi :as ffi]
-   [coffi.mem :as mem]
+   [babashka.ffi :as ffi]
+   [sqlite4clj.core :as d]
    [sqlite4clj.impl.api :as api]
-   [sqlite4clj.core :as d]))
+   [sqlite4clj.impl.ffi-wrapper :refer [defcfn]]))
 
 ;; -----------------------------
 ;; SESSION extension
@@ -12,78 +11,66 @@
 
 (defcfn session-create
   "sqlite3session_create"
-  [::mem/pointer ::mem/c-string ::mem/pointer] ::mem/int
+  [:pointer :string :pointer] :int
   sqlite3session-create-native
   [pdb]
-  (with-open [arena (mem/confined-arena)]
-    (let [ppSession (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [ppSession (ffi/alloc arena :pointer)
           code      (sqlite3session-create-native pdb "main" ppSession)]
       (if (api/sqlite-ok? code)
-        (mem/deserialize-from ppSession ::mem/pointer)
+        (ffi/read ppSession :pointer)
         (throw (api/sqlite-ex-info pdb code {}))))))
 
 (defcfn session-attach
-  sqlite3session_attach
-  [::mem/pointer ::mem/c-string] ::mem/int)
+  "sqlite3session_attach"
+  [:pointer :string] :int)
 
 (defcfn session-delete
-  sqlite3session_delete
-  [::mem/pointer] ::mem/int)
+  "sqlite3session_delete"
+  [:pointer] :void)
 
 (defcfn session-changeset
   "sqlite3session_changeset"
-  [::mem/pointer ::mem/pointer ::mem/pointer] ::mem/int
+  [:pointer :pointer :pointer] :int
   sqlite3session-patchset-native
   [pdb pSession]
-  (with-open [arena (mem/confined-arena)]
-    (let [pnPatchset (mem/alloc-instance ::mem/int arena)
-          ppPatchset (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [pnPatchset (ffi/alloc arena :int)
+          ppPatchset (ffi/alloc arena :pointer)
           code       (sqlite3session-patchset-native pSession
                        pnPatchset
                        ppPatchset)]
       (if (api/sqlite-ok? code)
-        [(mem/deserialize-from pnPatchset ::mem/int)
-         (mem/deserialize-from ppPatchset ::mem/pointer)]
+        [(ffi/read pnPatchset :int)
+         (ffi/read ppPatchset :pointer)]
         (throw (api/sqlite-ex-info pdb code {}))))))
 
 (defcfn changeset-invert
   "sqlite3changeset_invert"
-  [::mem/int ::mem/pointer
-   ::mem/pointer ::mem/pointer] ::mem/int
+  [:int :pointer
+   :pointer :pointer] :int
   sqlite3changeset-invert-native
   [pdb nInSet pInSet]
-  (with-open [arena (mem/confined-arena)]
-    (let [pnOutSet (mem/alloc-instance ::mem/int arena)
-          ppOutSet (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [pnOutSet (ffi/alloc arena :int)
+          ppOutSet (ffi/alloc arena :pointer)
           code     (sqlite3changeset-invert-native
                      nInSet pInSet
                      pnOutSet ppOutSet)]
       (if (api/sqlite-ok? code)
-        [(mem/deserialize-from pnOutSet ::mem/int)
-         (mem/deserialize-from ppOutSet ::mem/pointer)]
+        [(ffi/read pnOutSet :int)
+         (ffi/read ppOutSet :pointer)]
         (throw (api/sqlite-ex-info pdb code {}))))))
 
 (defcfn changeset-apply
-  sqlite3changeset_apply
-  [::mem/pointer ;; db
-   ::mem/int     ;; size of changeset
-   ::mem/pointer ;; changeset
-   ::mem/pointer ;; xFilter
-   ::mem/pointer ;; xConflict
-   ::mem/pointer ;; First arg to conflict
-   ] ::mem/int)
-
-(defcfn session-create
-  "sqlite3session_create"
-  [::mem/pointer ::mem/c-string ::mem/pointer] ::mem/int
-  sqlite3session-create-native
-  [pdb]
-  (with-open [arena (mem/confined-arena)]
-    (let [ppSession (mem/alloc-instance ::mem/pointer arena)
-          code      (sqlite3session-create-native pdb "main" ppSession)]
-      (if (api/sqlite-ok? code)
-        (mem/deserialize-from ppSession ::mem/pointer)
-        (throw (api/sqlite-ex-info pdb code {}))))))
+  "sqlite3changeset_apply"
+  [:pointer ;; db
+   :int     ;; size of changeset
+   :pointer ;; changeset
+   :pointer ;; xFilter
+   :pointer ;; xConflict
+   :pointer ;; First arg to conflict
+   ] :int)
 
 (defn new-session
   "Creates a session and attaches it to the database."
@@ -109,16 +96,12 @@
             [nSet pSet]             (session-changeset pdb pSession)
             _                       (session-delete pSession)
             [nInvertSet pInvertSet] (changeset-invert pdb nSet pSet)]
-        (with-open [arena (mem/confined-arena)]
+        (with-open [arena (ffi/confined-arena)]
           (let [x-conflict
                 ;; Fails if there's a conflict (there should never be a conflict)
                 ;; when using undo-session correctly.
-                (mem/serialize (fn [_ _ _] (int 0))
-                  [::ffi/fn
-                   [::mem/pointer ::mem/int ::mem/pointer]
-                   ::mem/int
-                   :raw-fn? true]
-                  arena)]
+                (ffi/callback arena (fn [_ _ _] (int 0))
+                  [:pointer :int :pointer] :int)]
             (changeset-apply pdb nInvertSet pInvertSet nil x-conflict nil)))
         (api/free pSet)
         (api/free pInvertSet)
@@ -126,54 +109,54 @@
 
 (defcfn changeset-start
   "sqlite3changeset_start"
-  [::mem/pointer ;; changeset iterator
-   ::mem/int     ;; size of changeset
-   ::mem/pointer ;; changeset
-   ] ::mem/int
+  [:pointer ;; changeset iterator
+   :int     ;; size of changeset
+   :pointer ;; changeset
+   ] :int
   sqlite3session-changeset-start-native
   [pdb nSet pSet]
-  (with-open [arena (mem/confined-arena)]
-    (let [ppChangesetIter (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [ppChangesetIter (ffi/alloc arena :pointer)
           code            (sqlite3session-changeset-start-native
                             ppChangesetIter nSet pSet)]
       (if (api/sqlite-ok? code)
-        (mem/deserialize-from ppChangesetIter ::mem/pointer)
+        (ffi/read ppChangesetIter :pointer)
         (throw (api/sqlite-ex-info pdb code {}))))))
 
 (defcfn changeset-next
-  sqlite3changeset_next [::mem/pointer] ::mem/int)
+  "sqlite3changeset_next" [:pointer] :int)
 
 (def op->statemen {18 "INSERT" 9  "DELETE" 23 "UPDATE"})
 
 (defcfn changeset-op
   "sqlite3changeset_op"
-  [::mem/pointer ;; IN: changeset iterator
-   ::mem/pointer ;; OUT: table name
-   ::mem/pointer ;; OUT: number of columns in table
-   ::mem/pointer ;; OUT: statement
-   ::mem/pointer ;; OUT: indirect change
-   ] ::mem/int
+  [:pointer ;; IN: changeset iterator
+   :pointer ;; OUT: table name
+   :pointer ;; OUT: number of columns in table
+   :pointer ;; OUT: statement
+   :pointer ;; OUT: indirect change
+   ] :int
   sqlite3changeset-op-native
   [pdb pChangesetIter]
-  (with-open [arena (mem/confined-arena)]
-    (let [pzTab      (mem/alloc-instance ::mem/pointer arena)
-          pnCol      (mem/alloc-instance ::mem/pointer arena)
-          pOp        (mem/alloc-instance ::mem/pointer arena)
-          pbIndirect (mem/alloc-instance ::mem/pointer arena)
+  (with-open [arena (ffi/confined-arena)]
+    (let [pzTab      (ffi/alloc arena :pointer)
+          pnCol      (ffi/alloc arena :int)
+          pOp        (ffi/alloc arena :int)
+          pbIndirect (ffi/alloc arena :int)
 
           code (sqlite3changeset-op-native
                  pChangesetIter pzTab pnCol pOp pbIndirect)]
       (if (api/sqlite-ok? code)
-        [(mem/deserialize-from pzTab      ::mem/c-string)
-         (mem/deserialize-from pnCol      ::mem/int)
-         (-> (mem/deserialize-from pOp        ::mem/int)
+        [(ffi/read pzTab :string)
+         (ffi/read pnCol :int)
+         (-> (ffi/read pOp :int)
              op->statemen)
-         (if (= (mem/deserialize-from pbIndirect ::mem/int) 0)
+         (if (= (ffi/read pbIndirect :int) 0)
            false true)]
         (throw (api/sqlite-ex-info pdb code {}))))))
 
 (defcfn changeset-finalize
-  sqlite3changeset_finalize [::mem/pointer] ::mem/int)
+  "sqlite3changeset_finalize" [:pointer] :int)
 
 (defn view-session-changeset
   "Returns changeset data from session as edn."

--- a/test/sqlite4clj/core_test.clj
+++ b/test/sqlite4clj/core_test.clj
@@ -14,6 +14,28 @@
           (d/q (:writer db) ["SELECT x'', ?" (byte-array 0)])]
       (is (= [[] []] [(vec native-empty) (vec encoded-empty)])))))
 
+(deftest decoded-blobs-outlive-their-database
+  (let [captured (atom [])
+        raw-values [[] [0 -1 0 127] (vec (range 64))]
+        documents (mapv (fn [id] {:id id :text "世界" :tags [:a :b]}) (range 3))
+        rows
+        (with-db [db (d/init-db! ":memory:" {:pool-size 1})]
+          (d/q (:writer db) ["CREATE TABLE retained_blobs (id INTEGER PRIMARY KEY, raw BLOB, data BLOB)"])
+          (doseq [id (range 3)]
+            (d/q (:writer db) ["INSERT INTO retained_blobs VALUES (?, ?, ?)"
+                              id (byte-array (raw-values id)) (documents id)]))
+          (d/create-function db "retain_blob"
+            (fn [v] (swap! captured conj v) 0) {:arity 1})
+          (let [rows (d/q (:writer db)
+                       ["SELECT raw, data, retain_blob(raw), retain_blob(data) FROM retained_blobs ORDER BY id"])]
+            (d/q (:writer db) ["UPDATE retained_blobs SET raw = ?, data = ?"
+                              (byte-array [9]) {:replaced true}])
+            rows))]
+    (is (= (mapv vector raw-values documents)
+           (mapv (fn [[raw data]] [(vec raw) data]) rows)))
+    (is (= (vec (interleave raw-values documents))
+           (mapv (fn [v] (if (bytes? v) (vec v) v)) @captured)))))
+
 (deftest pool-objects-are-references
   (testing "Ensure pool objects are references to connections."
     (with-db [db (test-db)]

--- a/test/sqlite4clj/core_test.clj
+++ b/test/sqlite4clj/core_test.clj
@@ -6,6 +6,14 @@
 
 (use-fixtures :once test-fixture)
 
+(deftest native-values-round-trip
+  (with-db [db (test-db)]
+    (doseq [value [Long/MIN_VALUE Long/MAX_VALUE 1.25 "世界 🌍" "" nil]]
+      (is (= [value] (d/q (:writer db) ["SELECT ?" value]))))
+    (let [[[native-empty encoded-empty]]
+          (d/q (:writer db) ["SELECT x'', ?" (byte-array 0)])]
+      (is (= [[] []] [(vec native-empty) (vec encoded-empty)])))))
+
 (deftest pool-objects-are-references
   (testing "Ensure pool objects are references to connections."
     (with-db [db (test-db)]

--- a/test/sqlite4clj/session_test.clj
+++ b/test/sqlite4clj/session_test.clj
@@ -1,0 +1,23 @@
+(ns sqlite4clj.session-test
+  (:require
+   [clojure.test :refer [deftest is use-fixtures]]
+   [sqlite4clj.core :as d]
+   [sqlite4clj.session :as session]
+   [sqlite4clj.test-common :refer [test-db test-fixture with-db]]))
+
+(use-fixtures :once test-fixture)
+
+(deftest changesets-can-be-inspected-and-undone
+  (with-db [db (test-db)]
+    (d/q (:writer db) ["CREATE TABLE session_items (id INTEGER PRIMARY KEY)"])
+    (d/with-conn [conn (:writer db)]
+      (let [s (session/new-session conn)]
+        (try
+          (d/q conn ["INSERT INTO session_items VALUES (1)"])
+          (is (= [["session_items" 1 "INSERT" false]]
+                 (session/view-session-changeset conn s)))
+          (session/undo-session conn s)
+          (is (= [0] (d/q conn ["SELECT count(*) FROM session_items"])))
+          (is (nil? @s))
+          (finally
+            (session/cancel-session s)))))))


### PR DESCRIPTION
This PR migrates from coffi to babashka/ffi.

There's also a patch that increases perf by avoiding creating an arena for every decoded value, this fix would have also been relevant to the coffi version. So if you don't accept this PR in full, that commit should be used as fodder for perf-improvements in the coffi version.

I've created it as a draft because to avoid perf losses the following three upstream perf-related PRs must be merged into babashka/ffi:

- https://github.com/babashka/ffi/pull/38
- https://github.com/babashka/ffi/pull/36
- https://github.com/babashka/ffi/pull/37

(I measured perf using the benchmark added in https://github.com/andersmurphy/sqlite4clj/pull/25)

In my JVM benchmarks, sqlite4clj with babashka/ffi (w/ perf patches) took roughly 7–36% less time than the coffi version across seven workloads. Each workload was faster!

- Cached scalar queries: 14% less time
- EDN scans: 15% less time
- Blob scans: 23% less time
- Direct native calls: 36% less time


### why switch from coffi to babashka/ffi?

This started as an exercise of babashka/ffi to see what it was capable of. But there several reasons that I think it should land:

1. I want to see a unified api for native-image, babashka and JVM clojure. babashka/ffi promises to be that, whereas coffi requires java compilation and doesn't aim for babashka compat.
2. the coffi maintainer doesn't have much time for maintenance, and I've had to maintain/carry some patches to make it work for my usecases

